### PR TITLE
Audit Angular client dependencies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Install dependencies
         working-directory: client
         run: pnpm install --frozen-lockfile
+      - name: Audit production dependencies
+        working-directory: client
+        run: pnpm audit --prod --audit-level high
       - name: Build Angular client
         working-directory: client
         run: pnpm build


### PR DESCRIPTION
## Summary
- add a production dependency audit for the Angular client
- preserve the existing Angular 22/pnpm and Spring Boot modernization baseline

## Verification
- client frozen install — passed
- client production audit — no known vulnerabilities
- client production build — passed
- client Vitest — 2 tests passed
- Maven verification remains enforced by GitHub Actions; the local runner could not reach Maven Central

This supersedes the obsolete Angular 5/npm Snyk upgrade PRs.